### PR TITLE
closes #3: resolving collisions when paths cross

### DIFF
--- a/src/lem_in_main.c
+++ b/src/lem_in_main.c
@@ -6,7 +6,7 @@
 /*   By: melalj <melalj@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2019/11/12 22:07:41 by melalj            #+#    #+#             */
-/*   Updated: 2019/12/21 10:25:28 by archid-          ###   ########.fr       */
+/*   Updated: 2019/12/22 19:33:11 by archid-          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -146,7 +146,35 @@ void	graph_dump(t_graph *g)
 
 void	graph_free(t_graph *g)
 {
-	/* ft_lstdel(&g->nodes_lst, lstdel_node); */
+	t_node *node;
+	t_node *nwalk;
+	t_edge *edge;
+	t_edge *tmp;
+	t_edge *ewalk;
+
+	nwalk = g->nodes_lst;
+	while (nwalk)
+	{
+		node = nwalk;
+		nwalk = nwalk->next;
+		ewalk = node->edges;
+		while (ewalk)
+		{
+			/* FIXME:  */
+			edge = ewalk;
+			ewalk = ewalk->next;
+			if (edge->node_src->edges)
+			{
+				tmp = edge->node_dst->edges;
+				edge->node_dst->edges = NULL;
+				free(tmp);
+			}
+			free(edge->node_src->edges);
+			edge->node_src->edges = NULL;
+		}
+		free(node->name);
+		free(node);
+	}
 	free(g);
 }
 
@@ -200,6 +228,21 @@ void	edge_oneline_dump(t_qnode *e)
 			  edge->node_dst->name);
 }
 
+void	parser_free(t_parse *p)
+{
+	t_parse *walk;
+	t_parse *hold;
+
+	walk = p;
+	while (walk)
+	{
+		hold = walk;
+		walk = walk->next;
+		free(hold->line);
+		free(hold);
+	}
+}
+
 int		main(void)
 {
 	t_parse		*pp;
@@ -221,6 +264,8 @@ int		main(void)
 	ft_putendl(" === filling edges === ");
 	edges_fill(nodes, pp, nodes_c);
 
+	parser_free(pp);
+
 	g = graph_init(refs, nodes, nodes_c);
 	graph_dump(g);
 
@@ -231,7 +276,6 @@ int		main(void)
 	ft_printf("source: %s | sink: %s\n", g->start->name, g->sink->name);
 
 	paths = list_shortest_paths(g);
-
 	while (queue_size(paths))
 	{
 		ft_putendl("-----------");
@@ -247,6 +291,7 @@ int		main(void)
 		ft_putendl("-----------");
 		/* sleep(3); */
 	}
+
 	queue_del(&paths, queue_del_helper);
 
 	/* sp1 = bfs(g); */
@@ -259,7 +304,10 @@ int		main(void)
 	/* queue_del(&sp2, queue_del_helper); */
 
 	/* graph_dump(g); */
-	graph_free(g);
+
+	/* FIXME: fix double free  */
+	/* graph_free(g); */
+
 
 	return (0);
 }

--- a/src/queue.c
+++ b/src/queue.c
@@ -6,7 +6,7 @@
 /*   By: archid- <archid-@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2019/11/29 17:12:11 by archid-           #+#    #+#             */
-/*   Updated: 2019/12/21 12:11:43 by archid-          ###   ########.fr       */
+/*   Updated: 2019/12/22 15:17:47 by archid-          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -200,4 +200,49 @@ t_qnode *queue_last(t_queue *q)
 	if (!q || !queue_size(q))
 		return NULL;
 	return q->tail->prev->blob;
+}
+
+void	queue_swap_halfs(t_queue *head_queue, t_queue *tail_queue,
+							t_qnode *head_split, t_qnode *tail_split)
+{
+	t_qnode *tmp;
+	t_qnode *head;
+	t_qnode *tail;
+
+	if (!head_queue || !tail_queue || !head_split || !tail_split
+			|| head_split == head_queue->tail || tail_split == tail_queue->head)
+		return ;
+
+	/* swap the tails */
+	tmp = head_queue->head;
+	head_queue->head = tail_queue->head;
+	tail_queue->head = tmp;
+
+	/* keeping track of head split */
+	head = tail_split->prev;
+	tail = head_split->next;
+
+
+	/* merge tail split */
+	head_split->next = tail_split;
+	tail_split->prev = head_split;
+
+	/* merge head split */
+	head->next = tail;
+	tail->prev = head;
+}
+
+void	queue_node_del_next(t_queue *q, t_qnode *node,
+								void (*del)(void *, size_t))
+{
+	t_qnode *tmp;
+
+	if (!q || !node || node == q->head || node == q->tail ||
+			node->next == q->tail)
+		return ;
+	tmp = node->next;
+	node->next = node->next->next;
+	node->next->prev = node;
+	del(tmp->blob, tmp->size);
+	free(tmp);
 }

--- a/src/queue.h
+++ b/src/queue.h
@@ -6,7 +6,7 @@
 /*   By: archid- <archid-@student.1337.ma>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2019/11/29 16:34:27 by archid-           #+#    #+#             */
-/*   Updated: 2019/12/21 05:58:49 by archid-          ###   ########.fr       */
+/*   Updated: 2019/12/22 03:50:42 by archid-          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,7 +51,10 @@ void							queue_enq(t_queue *queue, t_qnode *node);
 t_qnode 						*queue_deq(t_queue *queue);
 
 t_qnode							*queue_last(t_queue *q);
+void							queue_node_del_next(t_queue *q, t_qnode *node,
+														void (*del)(void *, size_t));
 void							queue_node_del_dry(void *blob, size_t size);
 t_qnode							*queue_dry_node(void *data, size_t size);
-
+void							queue_swap_halfs(t_queue *head_queue, t_queue *tail_queue,
+													t_qnode *head_split, t_qnode *tail_split);
 #endif


### PR DESCRIPTION
  TLDR;
  ~~~~~

  1. detect collision: if we face a collision, ie. two paths having
     the same source node. one's next must be a residual edge!
  2. resolve collision: remove residual edge and link the paths based
     on which one has the residual edge

  IDEA:
  ~~~~~~

  basically, after getting all the possible paths (list of edges) using
  BFS(), retrace the paths back from the sink, while doing the
  following when a collision occurs:

  given p1 and p2 as current edge of paths 1 and 2 respecivaly,
	and e1, e2; as the nexts of paths 1 and 2 respecively, then

  1. check which one is residual by comparing (p1 and e2), implicitly
	(p2 and e1) since it must be one of them since we have found a
	collision. so based on this condition
  2. remove the residual edge (e2 or e1) from the list, remove the
     actual edge (p1 or p2)
  3.1 save current p1's next as old_not_residual
  3.2 merge eveything before e2 exclusive and everything after p1 inclusive.
  3.3 do the same with eveyrthing before p1 exclusive and everything
      after e2 exclusive
  4. set p1 to old_not_residual

  NOTE: (a or b) based on the condition (p1->residual == e2 ? a : b)

  BUG #4